### PR TITLE
Add deskewing only option

### DIFF
--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -27,6 +27,7 @@ dlio:
       leafSize: 0.25
 
   odom:
+    deskewing_only: true
 
     gravity: 9.80665
 

--- a/include/dlio/odom.h
+++ b/include/dlio/odom.h
@@ -284,6 +284,8 @@ private:
 
   bool deskew_;
 
+  bool deskew_only_;
+
   double gravity_;
 
   bool adaptive_params_;

--- a/launch/lidar_deskewing.launch
+++ b/launch/lidar_deskewing.launch
@@ -1,0 +1,41 @@
+<!--
+
+  Copyright (c)     
+
+  The Verifiable & Control-Theoretic Robotics (VECTR) Lab
+  University of California, Los Angeles
+
+  Authors: Kenny J. Chen, Ryan Nemiroff, Brett T. Lopez
+  Contact: {kennyjchen, ryguyn, btlopez}@ucla.edu
+
+-->
+
+<launch>
+
+  <arg name="robot_namespace" default="robot"/>
+  <arg name="rviz" default="false"/>
+
+  <arg name="pointcloud_topic" default="lidar"/>
+  <arg name="imu_topic" default="imu"/>
+
+  <!-- DLIO Odometry Node -->
+  <node ns="$(arg robot_namespace)" name="dlio_odom" pkg="direct_lidar_inertial_odometry" type="dlio_odom_node" output="screen" clear_params="true">
+
+    <!-- Load parameters -->
+    <rosparam file="$(find direct_lidar_inertial_odometry)/cfg/dlio.yaml" command="load"/>
+    <rosparam file="$(find direct_lidar_inertial_odometry)/cfg/params.yaml" command="load"/>
+
+    <!-- Subscriptions -->
+    <remap from="~pointcloud" to="$(arg pointcloud_topic)"/>
+    <remap from="~imu" to="$(arg imu_topic)"/>
+
+    <!-- Publications -->
+    <remap from="~odom"     to="dlio/odom_node/odom"/>
+    <remap from="~pose"     to="dlio/odom_node/pose"/>
+    <remap from="~path"     to="dlio/odom_node/path"/>
+    <remap from="~kf_pose"  to="dlio/odom_node/keyframes"/>
+    <remap from="~kf_cloud" to="dlio/odom_node/pointcloud/keyframe"/>
+    <remap from="~deskewed" to="dlio/odom_node/pointcloud/deskewed"/>
+
+  </node>
+</launch>


### PR DESCRIPTION
This PR is supposed to implement a deskewing only option that is supposed to exclude all functionality to publish odometry.

This way we can pass the deskewed cloud to our autonomous system with minimal delay.