### PR TITLE
[ROS2] Fix for params reading

### DIFF
--- a/cfg/dlio.yaml
+++ b/cfg/dlio.yaml
@@ -10,36 +10,28 @@
 #                                                         #
 ###########################################################
 
-dlio:
+/**:
   ros__parameters:
 
     version: 1.1.1
 
     adaptive: true
 
-    pointcloud:
-      deskew: true
-      voxelize: true
+    pointcloud/deskew: true
+    pointcloud/voxelize: true
 
-    imu:
-      calibration: true
-      intrinsics:
-        accel:
-          bias: [ 0.0, 0.0, 0.0 ]
-          sm:   [ 1.,  0.,  0.,
+    imu/calibration: true
+    imu/intrinsics/accel/bias: [ 0.0, 0.0, 0.0 ]
+    imu/intrinsics/accel/sm:   [ 1.,  0.,  0.,
                   0.,  1.,  0.,
                   0.,  0.,  1. ]
-        gyro:
-          bias: [ 0.0, 0.0, 0.0 ]
+    mu/intrinsics/gyro/bias: [ 0.0, 0.0, 0.0 ]
 
-    extrinsics:
-      baselink2imu:
-        t: [ 0.006253, -0.011775, 0.007645 ]
-        R: [ 1.,  0.,  0.,
+    extrinsics/baselink2imu/t: [ 0., 0., 0. ]
+    extrinsics/baselink2imu/R: [ -1.,  0.,  0.,
             0.,  1.,  0.,
-            0.,  0.,  1. ]
-      baselink2lidar:
-        t: [ 0.,  0.,  0. ]
-        R: [ 1.,  0.,  0.,
+            0.,  0.,  -1. ]
+    extrinsics/baselink2lidar/t: [ 0.,  0.,  0. ]
+    extrinsics/baselink2lidar/R: [ 1.,  0.,  0.,
             0.,  1.,  0.,
             0.,  0.,  1. ]

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -10,64 +10,48 @@
 #                                                         #
 ###########################################################
 
-dlio:
+/**:
   ros__parameters:
+    use_sim_time: true
+    frames/odom: odom
+    frames/baselink: base_link
+    frames/lidar: lidar
+    frames/imu: imu
 
-    frames:
-      odom: odom
-      baselink: base_link
-      lidar: lidar
-      imu: imu
+    map/waitUntilMove: true
+    map/dense/filtered: false
+    map/sparse/frequency: 1.0
+    map/sparse/leafSize: 0.25
 
-    map:
-      waitUntilMove: true
-      dense:
-        filtered: false
-      sparse:
-        frequency: 1.0
-        leafSize: 0.25
+    odom/gravity: 9.80665
 
-    odom:
+    odom/imu/approximateGravity: false
+    odom/imu/calibration/gyro: true
+    odom/imu/calibration/accel: true
+    odom/imu/calibration/time: 3.0
+    odom/imu/bufferSize: 5000
 
-      gravity: 9.80665
+    odom/preprocessing/cropBoxFilter/size: 1.0
+    odom/preprocessing/voxelFilter/res: 0.25
 
-      imu:
-        approximateGravity: false
-        calibration:
-          gyro: true
-          accel: true
-          time: 3
-        bufferSize: 5000
+    odom/keyframe/threshD: 1.0
+    odom/keyframe/threshR: 45.0
 
-      preprocessing:
-        cropBoxFilter:
-          size: 1.0
-        voxelFilter:
-          res: 0.25
+    odom/submap/keyframe/knn: 10
+    odom/submap/keyframe/kcv: 10
+    odom/submap/keyframe/kcc: 10
+    odom/gicp/minNumPoints: 64
+    odom/gicp/kCorrespondences: 16
+    odom/gicp/maxCorrespondenceDistance: 0.5
+    odom/gicp/maxIterations: 32
+    odom/gicp/transformationEpsilon: 0.01
+    odom/gicp/rotationEpsilon: 0.01
+    odom/gicp/initLambdaFactor: 1e-9
 
-      keyframe:
-        threshD: 1.0
-        threshR: 45.0
-
-      submap:
-        keyframe:
-          knn: 10
-          kcv: 10
-          kcc: 10
-      gicp:
-        minNumPoints: 64
-        kCorrespondences: 16
-        maxCorrespondenceDistance: 0.5
-        maxIterations: 32
-        transformationEpsilon: 0.01
-        rotationEpsilon: 0.01
-        initLambdaFactor: 1e-9
-
-      geo:
-        Kp: 4.5
-        Kv: 11.25
-        Kq: 4.0
-        Kab: 2.25
-        Kgb: 1.0
-        abias_max: 5.0
-        gbias_max: 0.5
+    odom/geo/Kp: 4.5
+    odom/geo/Kv: 11.25
+    odom/geo/Kq: 4.0
+    odom/geo/Kab: 2.25
+    odom/geo/Kgb: 1.0
+    odom/geo/abias_max: 5.0
+    odom/geo/gbias_max: 0.5

--- a/launch/dlio.launch.py
+++ b/launch/dlio.launch.py
@@ -20,8 +20,8 @@ def generate_launch_description():
 
     # Set default arguments
     rviz = LaunchConfiguration('rviz', default='false')
-    pointcloud_topic = LaunchConfiguration('pointcloud_topic', default='points')
-    imu_topic = LaunchConfiguration('imu_topic', default='imu')
+    pointcloud_topic = LaunchConfiguration('pointcloud_topic', default='points_raw')
+    imu_topic = LaunchConfiguration('imu_topic', default='imu_raw')
 
     # Define arguments
     declare_rviz_arg = DeclareLaunchArgument(
@@ -59,7 +59,7 @@ def generate_launch_description():
             ('kf_pose', 'dlio/odom_node/keyframes'),
             ('kf_cloud', 'dlio/odom_node/pointcloud/keyframe'),
             ('deskewed', 'dlio/odom_node/pointcloud/deskewed'),
-        ]
+        ],
     )
 
     # DLIO Mapping Node
@@ -70,7 +70,7 @@ def generate_launch_description():
         parameters=[dlio_yaml_path, dlio_params_yaml_path],
         remappings=[
             ('keyframes', 'dlio/odom_node/pointcloud/keyframe'),
-        ]
+        ],
     )
 
     # RViz node

--- a/src/dlio/map.cc
+++ b/src/dlio/map.cc
@@ -41,13 +41,13 @@ dlio::MapNode::~MapNode() {}
 
 void dlio::MapNode::getParams() {
 
-  this->declare_parameter<std::string>("~dlio/odom/odom_frame", "odom");
-  this->declare_parameter<double>("~dlio/map/sparse/frequency", 1.0);
-  this->declare_parameter<double>("~dlio/map/sparse/leafSize", 0.5);
+  this->declare_parameter<std::string>("odom/odom_frame", "odom");
+  this->declare_parameter<double>("map/sparse/frequency", 1.0);
+  this->declare_parameter<double>("map/sparse/leafSize", 0.5);
 
-  this->get_parameter("~dlio/odom/odom_frame", this->odom_frame);
-  this->get_parameter("~dlio/map/sparse/frequency", this->publish_freq_);
-  this->get_parameter("~dlio/map/sparse/leafSize", this->leaf_size_);
+  this->get_parameter("odom/odom_frame", this->odom_frame);
+  this->get_parameter("map/sparse/frequency", this->publish_freq_);
+  this->get_parameter("map/sparse/leafSize", this->leaf_size_);
 }
 
 void dlio::MapNode::start() {


### PR DESCRIPTION
Hey! Firstly, thanks for great paper and code!
I was trying to test DLIO (ROS2 branch) and found that there seem to be some issues. This may also be the cause of #26 .
I am using Ubuntu 22.04 and ROS2 Humble.

Firstly, there seems to be some issues with the writing of the parameter file *. yaml, which prevents the algorithm node from successfully reading the parameters in yaml. The location and mapping results are poor when using the default parameters in the *. cpp file. I mainly modified the format of yaml, and the parameter names in the *. cpp file.

Another small issue is that when `map/sense/filtered` is set to false, odom_node will crash. The reason I found is `this ->deskewed_` The height and width in the attributes of scan are both 0, resulting in subsequent `pcl:: transformPointCloud (* published_cloud, * deskewed_scan_t_, Tcloud);` Collapse. So I choose to create the `deskewed_scan_` with height and width, instead of using `resize`.

Finally, thanks again for this extremely good work!