### PR TITLE
add param to select if imu accelerations are normalized by gravity

### DIFF
--- a/cfg/dlio.yaml
+++ b/cfg/dlio.yaml
@@ -22,6 +22,7 @@ dlio:
 
   imu:
     calibration: true
+    normalized: true
     intrinsics:
       accel:
         bias: [ 0.0, 0.0, 0.0 ]

--- a/include/dlio/odom.h
+++ b/include/dlio/odom.h
@@ -315,6 +315,7 @@ private:
   bool calibrate_gyro_;
   bool calibrate_accel_;
   bool gravity_align_;
+  bool imu_normalized_;
   double imu_calib_time_;
   int imu_buffer_size_;
   Eigen::Matrix3f imu_accel_sm_;

--- a/src/dlio/odom.cc
+++ b/src/dlio/odom.cc
@@ -259,6 +259,7 @@ void dlio::OdomNode::getParams() {
 
   ros::param::param<bool>("~dlio/odom/imu/approximateGravity", this->gravity_align_, true);
   ros::param::param<bool>("~dlio/imu/calibration", this->imu_calibrate_, true);
+  ros::param::param<bool>("~dlio/imu/normalized", this->imu_normalized_, false);
   ros::param::param<std::vector<float>>("~dlio/imu/intrinsics/accel/bias", prior_accel_bias, accel_default);
   ros::param::param<std::vector<float>>("~dlio/imu/intrinsics/gyro/bias", prior_gyro_bias, gyro_default);
 
@@ -867,7 +868,7 @@ void dlio::OdomNode::callbackImu(const sensor_msgs::Imu::ConstPtr& imu_raw) {
   ang_vel[1] = imu->angular_velocity.y;
   ang_vel[2] = imu->angular_velocity.z;
 
-  if (this->sensor == dlio::SensorType::LIVOX) {
+  if (this->imu_normalized_) {
     lin_accel[0] = imu->linear_acceleration.x * this->gravity_;
     lin_accel[1] = imu->linear_acceleration.y * this->gravity_;
     lin_accel[2] = imu->linear_acceleration.z * this->gravity_;


### PR DESCRIPTION
This PR adds a new parameter to select if the IMU accelerations are normalized by gravity (as in the livox driver). This allows to use livox point clouds also with different IMUs.