### PR TITLE
fix dlio::MapNode::savePcd

### DIFF
--- a/src/dlio/map.cc
+++ b/src/dlio/map.cc
@@ -85,8 +85,8 @@ bool dlio::MapNode::savePcd(direct_lidar_inertial_odometry::save_pcd::Request& r
 
   if (!std::filesystem::is_directory(p)) {
     std::cout << "Could not find directory " << p << std::endl;
-    res->success = false;
-    return;
+    res.success = false;
+    return false;
   }
   
   std::cout << std::setprecision(2) << "Saving map to " << p + "/dlio_map.pcd"


### PR DESCRIPTION
fixes compilation error: https://github.com/vectr-ucla/direct_lidar_inertial_odometry/issues/50

I introduced the bug here: https://github.com/vectr-ucla/direct_lidar_inertial_odometry/pull/46/commits/bd16defb3eba903841c1cd30d8bf6724385a430f

The commit was ment for ROS2 branch, not ROS1.