### PR TITLE
Add verbosity flag to optionally prevent excessive std::cout writes

### DIFF
--- a/include/dlio/odom.h
+++ b/include/dlio/odom.h
@@ -281,6 +281,7 @@ private:
   // Parameters
   std::string version_;
   int num_threads_;
+  bool verbose;
 
   bool deskew_;
 

--- a/src/dlio/odom.cc
+++ b/src/dlio/odom.cc
@@ -301,10 +301,13 @@ void dlio::OdomNode::getParams() {
   ros::param::param<double>("~dlio/odom/geo/abias_max", this->geo_abias_max_, 1.0);
   ros::param::param<double>("~dlio/odom/geo/gbias_max", this->geo_gbias_max_, 1.0);
 
-
+  ros::param::param::<bool>("~dlio/verbose", this->verbose, true);
 }
 
 void dlio::OdomNode::start() {
+  if (!this->verbose) {
+    return;
+  }
 
   printf("\033[2J\033[1;1H");
   std::cout << std::endl
@@ -851,11 +854,12 @@ void dlio::OdomNode::callbackPointCloud(const sensor_msgs::PointCloud2ConstPtr& 
   this->gicp_hasConverged = this->gicp.hasConverged();
 
   // Debug statements and publish custom DLIO message
-  this->debug_thread = std::thread( &dlio::OdomNode::debug, this );
-  this->debug_thread.detach();
-
+  if (this->verbose) {
+    this->debug_thread = std::thread( &dlio::OdomNode::debug, this );
+    this->debug_thread.detach();
+  }
+  
   this->geo.first_opt_done = true;
-
 }
 
 void dlio::OdomNode::callbackImu(const sensor_msgs::Imu::ConstPtr& imu_raw) {

--- a/src/dlio/odom.cc
+++ b/src/dlio/odom.cc
@@ -301,7 +301,7 @@ void dlio::OdomNode::getParams() {
   ros::param::param<double>("~dlio/odom/geo/abias_max", this->geo_abias_max_, 1.0);
   ros::param::param<double>("~dlio/odom/geo/gbias_max", this->geo_gbias_max_, 1.0);
 
-  ros::param::param::<bool>("~dlio/verbose", this->verbose, true);
+  ros::param::param<bool>("~dlio/verbose", this->verbose, true);
 }
 
 void dlio::OdomNode::start() {


### PR DESCRIPTION
Since DLIO writes directly to `std::cout`, as opposed to using ROS' output system (`ROS_INFO` etc.) it's difficult to control the amount of terminal output you get. For example, it was quite difficult for me to read the estimated attitudes and biases, as this got overwritten by the info box. This PR adds a verbosity flag which removes the info box from the terminal output, if set to false. 