### PR TITLE
Limit number of malloc arenas to 1 

### DIFF
--- a/include/dlio/dlio.h
+++ b/include/dlio/dlio.h
@@ -33,6 +33,7 @@
 #include <sys/times.h>
 #include <sys/vtimes.h>
 #include <thread>
+#include <malloc.h>
 
 template <typename T>
 std::string to_string_with_precision(const T a_value, const int n = 6)

--- a/src/dlio/map_node.cc
+++ b/src/dlio/map_node.cc
@@ -14,6 +14,8 @@
 
 int main(int argc, char** argv) {
 
+  mallopt(M_ARENA_MAX, 1);
+
   ros::init(argc, argv, "dlio_map_node");
   ros::NodeHandle nh("~");
 

--- a/src/dlio/odom_node.cc
+++ b/src/dlio/odom_node.cc
@@ -14,6 +14,8 @@
 
 int main(int argc, char** argv) {
 
+  mallopt(M_ARENA_MAX, 1);
+  
   ros::init(argc, argv, "dlio_odom_node");
   ros::NodeHandle nh("~");
 


### PR DESCRIPTION
Allocating a ton of pointclouds sets the preferred chunk size high, so that when new arenas are created, they are very large. This change forces threads to share one arena instead of creating new ones.

More info [here](https://docs.google.com/document/d/1-x-oG1D0qH-vzmA8Iq_vGjH9AA3jR_09DheiSMGvKOM/edit
).