### PR TITLE
Update dlio.yaml to reflect master branch

### DIFF
--- a/cfg/dlio.yaml
+++ b/cfg/dlio.yaml
@@ -27,10 +27,10 @@
                                  0.,  0.,  1. ]
     imu/intrinsics/gyro/bias: [ 0.0, 0.0, 0.0 ]
 
-    extrinsics/baselink2imu/t: [ 0., 0., 0. ]
-    extrinsics/baselink2imu/R: [ -1.,  0.,  0.,
-                                  0.,  1.,  0.,
-                                  0.,  0.,  -1. ]
+    extrinsics/baselink2imu/t: [ 0.006253, -0.011775, 0.007645 ] 
+    extrinsics/baselink2imu/R: [ 1.,  0.,  0.,
+                                 0.,  1.,  0.,
+                                 0.,  0.,  1. ]
     extrinsics/baselink2lidar/t: [ 0.,  0.,  0. ]
     extrinsics/baselink2lidar/R: [ 1.,  0.,  0.,
                                    0.,  1.,  0.,


### PR DESCRIPTION
Brought the default IMU extrinsic configuration in line with what is present in the master branch, as shown in #78 