### PR TITLE
Remove `ament_export_libraries`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,6 @@ target_link_libraries(dlio_map_node ${PCL_LIBRARIES}  ${cpp_typesupport_target})
 ament_target_dependencies(dlio_map_node "tf2_ros" "pcl_ros" "pcl_conversions" "rclcpp")
 
 ament_export_include_directories(include)
-ament_export_libraries(nano_gicp nanoflann)
 ament_export_dependencies(rclcpp std_msgs sensor_msgs geometry_msgs pcl_ros)
 ament_package()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ target_link_libraries(dlio_map_node ${PCL_LIBRARIES}  ${cpp_typesupport_target})
 ament_target_dependencies(dlio_map_node "tf2_ros" "pcl_ros" "pcl_conversions" "rclcpp")
 
 ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME} nano_gicp nanoflann)
+ament_export_libraries(nano_gicp nanoflann)
 ament_export_dependencies(rclcpp std_msgs sensor_msgs geometry_msgs pcl_ros)
 ament_package()
 


### PR DESCRIPTION
When I use the package in my workspace, and I have another package that relies on this, I get this error:

```
--- stderr: sm_v2                                                                                                                                                                                   
CMake Error at /home/yossi/cramim2_ws/install/direct_lidar_inertial_odometry/share/direct_lidar_inertial_odometry/cmake/ament_cmake_export_libraries-extras.cmake:48 (message):
  Package 'direct_lidar_inertial_odometry' exports the library
  'direct_lidar_inertial_odometry' which couldn't be found
Call Stack (most recent call first):
  /home/yossi/cramim2_ws/install/direct_lidar_inertial_odometry/share/direct_lidar_inertial_odometry/cmake/direct_lidar_inertial_odometryConfig.cmake:41 (include)
  CMakeLists.txt:39 (find_package)
---
Ubuntu 22.04, ROS Humble
```

I see that there's no `add_library(${PROJECT_NAME})` in the file as well.

Also, the libraties nano_gicp, nanoflann are exported but not installed, so I get similar errors as well.

Removing the `ament_export_libraries` makes it work without errors.

