### PR TITLE
Set `prev_imu_stamp` on IMU calibration

### DIFF
--- a/src/dlio/odom.cc
+++ b/src/dlio/odom.cc
@@ -970,7 +970,7 @@ void dlio::OdomNode::callbackImu(const sensor_msgs::Imu::ConstPtr& imu_raw) {
       }
 
       this->imu_calibrated = true;
-
+      this->prev_imu_stamp = imu->header.stamp.toSec();
     }
 
   } else {


### PR DESCRIPTION
Previously, `prev_imu_stamp` would be 0, while the current timestamp would be the time since 1970, leading to a large value for `dt`.

[More here](https://docs.google.com/presentation/d/1CgxxEWnO-rgXmv_Q620DcvosopD56G4jJ3ObzA69JqI/edit?usp=sharing)