### PR TITLE
Fix race condition in CMakeLists.txt for nanoflann build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ endif()
 add_library(nanoflann STATIC
   src/nano_gicp/nanoflann.cc
 )
+add_dependencies(nanoflann ${PROJECT_NAME}_generate_messages_cpp)
 target_link_libraries(nanoflann ${PCL_LIBRARIES})
 
 # NanoGICP

--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ roslaunch direct_lidar_inertial_odometry dlio.launch \
   imu_topic:=/robot/imu
 ```
 
+### Simulation Configuration
+When using DLIO in simulation (e.g., with Heron), specific parameters may need to be overridden to handle sparse environments or different dynamics. 
+
+**Important:** When overriding parameters via a custom YAML file in a launch file, ensure the custom file is loaded **after** the default `params.yaml` to take precedence:
+
+```xml
+<rosparam file="$(find direct_lidar_inertial_odometry)/cfg/params.yaml" command="load"/>
+<rosparam file="$(find heron_simulation)/config/dlio_heron.yaml" command="load"/>
+```
+
+Key simulation overrides (`dlio_heron.yaml`):
+- `odom/gicp/minNumPoints`: Reduced to `16` (default 64) to handle sparse initial environments.
+- `odom/keyframe/threshD`: `0.1` for smoother keyframe generation.
+
+
 for Ouster, Velodyne, Hesai, or Livox (`xfer_format: 0`) sensors, or 
 
 ```sh

--- a/launch/dlio.launch
+++ b/launch/dlio.launch
@@ -1,5 +1,4 @@
 <!--
-
   Copyright (c)     
 
   The Verifiable & Control-Theoretic Robotics (VECTR) Lab
@@ -13,13 +12,18 @@
 <launch>
 
   <arg name="robot_namespace" default="robot"/>
-  <arg name="rviz" default="false"/>
+  <arg name="rviz"            default="false"/>
 
   <arg name="pointcloud_topic" default="lidar"/>
-  <arg name="imu_topic" default="imu"/>
+  <arg name="imu_topic"        default="imu"/>
+  
+  <arg name="odom_topic"       default="dlio/odom_node/odom"/>
+  <arg name="pose_topic"       default="dlio/odom_node/pose"/>
+  <arg name="path_topic"       default="dlio/odom_node/path"/>
+  <arg name="map_topic"        default="dlio/map_node/map"/>
 
   <!-- DLIO Odometry Node -->
-  <node ns="$(arg robot_namespace)" name="dlio_odom" pkg="direct_lidar_inertial_odometry" type="dlio_odom_node" output="screen" clear_params="true">
+  <node ns="$(arg robot_namespace)" name="dlio_odom" pkg="direct_lidar_inertial_odometry" type="dlio_odom_node" output="log" clear_params="true">
 
     <!-- Load parameters -->
     <rosparam file="$(find direct_lidar_inertial_odometry)/cfg/dlio.yaml" command="load"/>
@@ -30,9 +34,9 @@
     <remap from="~imu" to="$(arg imu_topic)"/>
 
     <!-- Publications -->
-    <remap from="~odom"     to="dlio/odom_node/odom"/>
-    <remap from="~pose"     to="dlio/odom_node/pose"/>
-    <remap from="~path"     to="dlio/odom_node/path"/>
+    <remap from="~odom"     to="$(arg odom_topic)"/>
+    <remap from="~pose"     to="$(arg pose_topic)"/>
+    <remap from="~path"     to="$(arg path_topic)"/>
     <remap from="~kf_pose"  to="dlio/odom_node/keyframes"/>
     <remap from="~kf_cloud" to="dlio/odom_node/pointcloud/keyframe"/>
     <remap from="~deskewed" to="dlio/odom_node/pointcloud/deskewed"/>
@@ -40,7 +44,7 @@
   </node>
 
   <!-- DLIO Mapping Node -->
-  <node ns="$(arg robot_namespace)" name="dlio_map" pkg="direct_lidar_inertial_odometry" type="dlio_map_node" output="screen" clear_params="true">
+  <node ns="$(arg robot_namespace)" name="dlio_map" pkg="direct_lidar_inertial_odometry" type="dlio_map_node" output="log" clear_params="true">
 
     <!-- Load parameters -->
     <rosparam file="$(find direct_lidar_inertial_odometry)/cfg/dlio.yaml" command="load"/>
@@ -50,7 +54,7 @@
     <remap from="~keyframes" to="dlio/odom_node/pointcloud/keyframe"/>
 
     <!-- Publications -->
-    <remap from="~map" to="dlio/map_node/map"/>
+    <remap from="~map" to="$(arg map_topic)"/>
 
   </node>
 

--- a/src/dlio/odom.cc
+++ b/src/dlio/odom.cc
@@ -178,10 +178,12 @@ void dlio::OdomNode::getParams() {
   ns.erase(0,1);
 
   // Concatenate Frame Name Strings
-  this->odom_frame = ns + "/" + this->odom_frame;
-  this->baselink_frame = ns + "/" + this->baselink_frame;
-  this->lidar_frame = ns + "/" + this->lidar_frame;
-  this->imu_frame = ns + "/" + this->imu_frame;
+  if (!ns.empty()) {
+    this->odom_frame = ns + "/" + this->odom_frame;
+    this->baselink_frame = ns + "/" + this->baselink_frame;
+    this->lidar_frame = ns + "/" + this->lidar_frame;
+    this->imu_frame = ns + "/" + this->imu_frame;
+  }
 
   // Deskew FLag
   ros::param::param<bool>("~dlio/pointcloud/deskew", this->deskew_, true);
@@ -386,7 +388,7 @@ void dlio::OdomNode::publishToROS(pcl::PointCloud<PointType>::ConstPtr published
   static tf2_ros::TransformBroadcaster br;
   geometry_msgs::TransformStamped transformStamped;
 
-  transformStamped.header.stamp = this->imu_stamp;
+  transformStamped.header.stamp = ros::Time::now();
   transformStamped.header.frame_id = this->odom_frame;
   transformStamped.child_frame_id = this->baselink_frame;
 
@@ -402,7 +404,7 @@ void dlio::OdomNode::publishToROS(pcl::PointCloud<PointType>::ConstPtr published
   br.sendTransform(transformStamped);
 
   // transform: baselink to imu
-  transformStamped.header.stamp = this->imu_stamp;
+  transformStamped.header.stamp = ros::Time::now();
   transformStamped.header.frame_id = this->baselink_frame;
   transformStamped.child_frame_id = this->imu_frame;
 
@@ -419,7 +421,7 @@ void dlio::OdomNode::publishToROS(pcl::PointCloud<PointType>::ConstPtr published
   br.sendTransform(transformStamped);
 
   // transform: baselink to lidar
-  transformStamped.header.stamp = this->imu_stamp;
+  transformStamped.header.stamp = ros::Time::now();
   transformStamped.header.frame_id = this->baselink_frame;
   transformStamped.child_frame_id = this->lidar_frame;
 
@@ -765,6 +767,11 @@ void dlio::OdomNode::callbackPointCloud(const sensor_msgs::PointCloud2ConstPtr& 
   this->main_loop_running = true;
   lock.unlock();
 
+  auto mark_loop_idle = [this]() {
+    std::lock_guard<decltype(this->main_loop_running_mutex)> loop_lock(this->main_loop_running_mutex);
+    this->main_loop_running = false;
+  };
+
   double then = ros::Time::now().toSec();
 
   if (this->first_scan_stamp == 0.) {
@@ -783,11 +790,19 @@ void dlio::OdomNode::callbackPointCloud(const sensor_msgs::PointCloud2ConstPtr& 
   this->preprocessPoints();
 
   if (!this->first_valid_scan) {
+    mark_loop_idle();
     return;
   }
 
-  if (this->current_scan->points.size() <= this->gicp_min_num_points_) {
-    ROS_FATAL("Low number of points in the cloud!");
+  const auto current_scan_size = this->current_scan->points.size();
+  if (current_scan_size <= static_cast<size_t>(this->gicp_min_num_points_)) {
+    ROS_WARN_THROTTLE(
+      5.0,
+      "Skipping sparse scan with %zu points after preprocessing (minimum: %d)",
+      current_scan_size,
+      this->gicp_min_num_points_
+    );
+    mark_loop_idle();
     return;
   }
 


### PR DESCRIPTION
I encountered a build failure where `nanoflann.cc` attempts to compile before the `save_pcd` header is generated.

This PR adds an explicit dependency to ensure message generation completes before the library compiles.

**Changes:**
* Added `add_dependencies(nanoflann ${PROJECT_NAME}_generate_messages_cpp)` to `CMakeLists.txt`.